### PR TITLE
Partial ContainerBlock support

### DIFF
--- a/Markdown.Avalonia/IMarkdown.cs
+++ b/Markdown.Avalonia/IMarkdown.cs
@@ -13,6 +13,8 @@ namespace Markdown.Avalonia
         ICommand HyperlinkCommand { get; set; }
         IBitmapLoader BitmapLoader { get; set; }
 
+        IContainerBlockHandler ContainerBlockHandler { get; set; }
+            
         Control Transform(string text);
     }
 }

--- a/Markdown.Avalonia/Markdown.cs
+++ b/Markdown.Avalonia/Markdown.cs
@@ -1092,7 +1092,7 @@ namespace Markdown.Avalonia
 
             return Evaluate(
                             text, _containerBlockFirst, ContainerBlockEvaluator,
-                            sn => Evaluate(sn, _blockquote, ContainerBlockEvaluator, defaultHandler)
+                            sn => Evaluate(sn, _containerBlockFirst, ContainerBlockEvaluator, defaultHandler)
                            );
         }
         

--- a/Markdown.Avalonia/Markdown.cs
+++ b/Markdown.Avalonia/Markdown.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
@@ -99,6 +99,8 @@ namespace Markdown.Avalonia
             }
         }
 
+        public IContainerBlockHandler ContainerBlockHandler { get; set; }
+
         private Bitmap ImageNotFound { get; }
 
         #region dependencyobject property
@@ -157,13 +159,14 @@ namespace Markdown.Avalonia
                 text,
                 _codeBlockFirst, CodeBlocksWithLangEvaluator,
                 _listLevel > 0 ? _listNested : _listTopLevel, ListEvaluator,
-                s1 => DoBlockquotes(s1,
-                s2 => DoHeaders(s2,
-                s3 => DoHorizontalRules(s3,
-                s4 => DoTable(s4,
-                s5 => DoNote(s5, supportTextAlignment,
-                s6 => DoIndentCodeBlock(s6,
-                sn => FormParagraphs(sn, supportTextAlignment)))))))
+                s1 => DoContainerBlock(s1,
+                s2 => DoBlockquotes(s2,
+                s3 => DoHeaders(s3,
+                s4 => DoHorizontalRules(s4,
+                s5 => DoTable(s5,
+                s6 => DoNote(s6, supportTextAlignment,
+                s7 => DoIndentCodeBlock(s7,
+                sn => FormParagraphs(sn, supportTextAlignment))))))) )
             );
         }
 
@@ -934,7 +937,6 @@ namespace Markdown.Avalonia
 
         #endregion
 
-
         #region grammer - table
 
         private static readonly Regex _table = new Regex(@"
@@ -1067,7 +1069,53 @@ namespace Markdown.Avalonia
 
         #endregion
 
+        #region grammer - container block
 
+        private static Regex _containerBlockFirst = new Regex(@"
+                    ^          # Character before opening
+                    [ ]{0,3}
+                    (:{3,})          # $1 = Opening run of `
+                    ([^\n`]*)        # $2 = The container type
+                    \n
+                    ((.|\n)+?)       # $3 = The code block
+                    \n[ ]*
+                    \1
+                    (?!:)[\n]+", RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Compiled);
+
+        
+        private IEnumerable<Control> DoContainerBlock(string text, Func<string, IEnumerable<Control>> defaultHandler)
+        {
+            if (text is null)
+            {
+                Helper.ThrowArgNull(nameof(text));
+            }
+
+            return Evaluate(
+                            text, _containerBlockFirst, ContainerBlockEvaluator,
+                            sn => Evaluate(sn, _blockquote, ContainerBlockEvaluator, defaultHandler)
+                           );
+        }
+        
+        private Border ContainerBlockEvaluator(Match match)
+        {
+            if ( match is null )
+            {
+                Helper.ThrowArgNull(nameof(match));
+            }
+
+            if( ContainerBlockHandler == null )
+            {
+                Border _retVal = CodeBlocksEvaluator( null, match.Value );
+                _retVal.BorderBrush = Brushes.Red;
+
+                return _retVal;
+            }
+            
+            return ContainerBlockHandler?.ProvideControl( AssetPathRoot, match.Groups[2].Value, match.Groups[3].Value );
+        }
+        
+        #endregion
+        
         #region grammer - code block
 
         private static Regex _codeBlockFirst = new Regex(@"
@@ -1164,7 +1212,6 @@ namespace Markdown.Avalonia
 
         #endregion
 
-
         #region grammer - code
 
         private static Regex _codeSpan = new Regex(@"
@@ -1227,7 +1274,6 @@ namespace Markdown.Avalonia
         }
 
         #endregion
-
 
         #region grammer - textdecorations
 

--- a/Markdown.Avalonia/Utils/IContainerBlockHandler.cs
+++ b/Markdown.Avalonia/Utils/IContainerBlockHandler.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+
+namespace Markdown.Avalonia.Utils
+{
+  /// <summary>
+  /// support for Container blocks
+  /// https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
+  /// </summary>
+  public interface IContainerBlockHandler
+  {
+    /// <summary>
+    /// Custom text parsing & content generation
+    /// Based on https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
+    /// </summary>
+    /// <param name="assetPathRoot">Asset Path Root</param>
+    /// <param name="blockName">Block Name</param>
+    /// <param name="lines">Text to parse</param>
+    /// <returns>Controls</returns>
+    Border ProvideControl( string assetPathRoot,
+                           string blockName,
+                           string lines );
+  }
+}


### PR DESCRIPTION
I've took liberty to partially implement container blocks from
https://talk.commonmark.org/t/generic-directives-plugins-syntax/444

This feature allows to expand markdown functionality with pluggable content handling.

Container blocks generate content using IMarkdownEngine.ContainerBlockHandler wich can be provided from xaml

```xaml
 <reactiveUi:ReactiveUserControl.Resources>
        <markdownEx:VideoBlockHandler x:Key="myBlockHandler"/>
    </reactiveUi:ReactiveUserControl.Resources>
    <avalonia:MarkdownScrollViewer>
        <avalonia:MarkdownScrollViewer.Engine>
            <avalonia:Markdown
                ContainerBlockBlockHandler="{StaticResource myBlockHandler}"/>
        </avalonia:MarkdownScrollViewer.Engine>
  </avalonia:MarkdownScrollViewer>

```

ProvideControl takes 3 parameters 
- Asset Path Root (supplied by Markdown class )
- Block name (same as language in code block )
- Block text content

example markdown using JSON to set up video player

```markdown
::: video
        { 
            Source:"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
            Width:"640",
            Height:"480"
        }
:::
```

![image](https://user-images.githubusercontent.com/10960735/139957009-aeaf0b90-153c-4df0-a4b9-c588a9cf8b76.png)

If ContainerBlockHandler is not set, the block is handled as code.

![image](https://user-images.githubusercontent.com/10960735/139957115-18217d52-023e-43a8-ae71-c08c3558bf6f.png)
