### PR TITLE
Set high quality interpolation by default

### DIFF
--- a/ColorTextBlock.Avalonia/Geometies/BitmapGeometry.cs
+++ b/ColorTextBlock.Avalonia/Geometies/BitmapGeometry.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Avalonia.Visuals.Media.Imaging;
 
 namespace ColorTextBlock.Avalonia.Geometries
 {
@@ -29,7 +30,8 @@ namespace ColorTextBlock.Avalonia.Geometries
             ctx.DrawImage(
                 Bitmap,
                 new Rect(Bitmap.Size),
-                new Rect(Left, Top, Width, Height)
+                new Rect(Left, Top, Width, Height),
+                BitmapInterpolationMode.HighQuality
                 );
         }
     }


### PR DESCRIPTION
Right now BitmapGeometry is rendered using standard interpolation mode, that leads to distorted images in many cases :

![image](https://user-images.githubusercontent.com/10960735/147279930-a78198b8-5cd9-495b-af69-7dbeeff2aa0c.png)

switching interpolation mode to high quality produces much better result

![image](https://user-images.githubusercontent.com/10960735/147280003-955831ba-dcad-424f-bae2-97697c1ea192.png)
